### PR TITLE
trim spaces of the certificate before loading

### DIFF
--- a/pkg/cert/location.go
+++ b/pkg/cert/location.go
@@ -1,6 +1,7 @@
 package cert
 
 import (
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -93,7 +94,7 @@ func LoadCertificateFromStdin() (CertificateLocation, error) {
 
 func loadCertificate(fileName string, data []byte) (CertificateLocation, error) {
 
-	certificates, err := FromBytes(data)
+	certificates, err := FromBytes(bytes.TrimSpace(data))
 	if err != nil {
 		return CertificateLocation{}, fmt.Errorf("file %s: %w", fileName, err)
 	}


### PR DESCRIPTION
The parse failed when the certificate has extra spaces/newlines at the end of the file. And the error message is confusing

```
$ cat ca.crt | certinfo
--- [stdin] ---
file stdin: cannot find any PEM block
```

Call `TrimSpace` before reading the certificate.