### PR TITLE
Combine flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ certinfo [flags] [<file>|<host:port> ...]
 | -signature    | whether to print signature                                                                        |
 | -sort-expiry  | sort certificates by expiration date                                                              |
 | -subject-like | print certificates with issuer field containing supplied string                                   |
+| -more         | use a combination of the '-pem -signature -chains' flags                                          |
 | -version      | certinfo version                                                                                  |
 | -help         | help                                                                                              |
 +---------------+---------------------------------------------------------------------------------------------------+

--- a/flag.go
+++ b/flag.go
@@ -62,7 +62,7 @@ func ParseFlags() (Flags, error) {
 		"verbose logging")
 	flagSet.BoolVar(&flags.Version, "version", getBoolEnv("CERTINFO_VERSION", false),
 		"certinfo version")
-	flagSet.BoolVar(&flags.More, "more", getBoolEnv("CERTINFO_ALL", false), "combination of '-pem -signature -chains'")
+	flagSet.BoolVar(&flags.More, "more", getBoolEnv("CERTINFO_MORE", false), "combination of '-pem -signature -chains'")
 
 	flagSet.Usage = func() {
 		fmt.Fprint(flagSet.Output(), "Usage: certinfo [flags] [<file>|<host:port> ...]\n")

--- a/flag.go
+++ b/flag.go
@@ -24,6 +24,7 @@ type Flags struct {
 	PemOnly     bool
 	Verbose     bool
 	Version     bool
+	More        bool
 	Args        []string
 }
 
@@ -61,6 +62,7 @@ func ParseFlags() (Flags, error) {
 		"verbose logging")
 	flagSet.BoolVar(&flags.Version, "version", getBoolEnv("CERTINFO_VERSION", false),
 		"certinfo version")
+	flagSet.BoolVar(&flags.More, "more", getBoolEnv("CERTINFO_ALL", false), "combination of '-pem -signature -chains'")
 
 	flagSet.Usage = func() {
 		fmt.Fprint(flagSet.Output(), "Usage: certinfo [flags] [<file>|<host:port> ...]\n")
@@ -72,6 +74,14 @@ func ParseFlags() (Flags, error) {
 		return Flags{}, err
 	}
 	flags.Args = flagSet.Args()
+
+	// Combination of flags
+	if flags.More {
+		flags.Pem = true
+		flags.Signature = true
+		flags.Chains = true
+	}
+
 	return flags, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pete911/certinfo
 
-go 1.24
+go 1.25
 
 require github.com/stretchr/testify v1.11.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pete911/certinfo
 
-go 1.25
+go 1.24
 
 require github.com/stretchr/testify v1.11.1
 


### PR DESCRIPTION
I have added an option `-more` to combine a set of flags (`-pem -signature -chains`), as I use these a lot and not all of my servers have all my aliases.