### PR TITLE
Added functionality for protocal specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![pipeline](https://github.com/pete911/certinfo/actions/workflows/pipeline.yml/badge.svg)](https://github.com/pete911/certinfo/actions/workflows/pipeline.yml)
 
-> [!WARNING]  
+> [!WARNING]
 > If you installed previous versions (before `v1.0.34`) via brew, you need to reinstall (brew remove certinfo && brew install certinfo) to get updates
 
 Similar to `openssl x509 -in <file> -text` command, but handles chains, multiple files and TCP addresses. TLS/SSL
@@ -17,6 +17,9 @@ certinfo [flags] [<file>|<host:port> ...]
 **file** argument can be:
  - **local file path** `certinfo <filename>`
  - **TCP network address** `certinfo <host:port>` e.g. `certinfo google.com:443`
+   * `certinfo <host:port>` e.g. `certinfo google.com:443`
+   * `certinfo <proto://host>` e.g. `certinfo https://google.com`
+   * `certinfo <proto://host:port>` e.g. `certinfo https://google.com:443`
  - **stdin** `echo "<cert-content>" | certinfo`
 
 ```

--- a/flag.go
+++ b/flag.go
@@ -65,7 +65,7 @@ func ParseFlags() (Flags, error) {
 	flagSet.BoolVar(&flags.More, "more", getBoolEnv("CERTINFO_MORE", false), "combination of '-pem -signature -chains'")
 
 	flagSet.Usage = func() {
-		fmt.Fprint(flagSet.Output(), "Usage: certinfo [flags] [<file>|<host:port> ...]\n")
+		fmt.Fprint(flagSet.Output(), "Usage: certinfo [flags] [<file>|<host:port>|<proto://host>|<proto://host:port> ...]\n")
 		flagSet.PrintDefaults()
 	}
 	flags.Usage = flagSet.Usage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pete911/certinfo
 
-go 1.25
+go 1.26
 
 require github.com/stretchr/testify v1.11.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pete911/certinfo
 
-go 1.26
+go 1.25
 
 require github.com/stretchr/testify v1.11.1
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,13 @@ import (
 
 var Version = "dev"
 
+var protomap = map[string]string{
+		"https": "443",
+		"http":  "80",
+		"ssh":   "22",
+	}
+
+
 func main() {
 
 	flags, err := ParseFlags()
@@ -125,12 +132,6 @@ func stdUrl(arg string) string {
 		return arg
 	}
 
-	protomap := map[string]string{
-		"https": "443",
-		"http":  "80",
-		"ssh":   "22",
-	}
-
 	for proto, port := range protomap {
 		proto = proto + "://"
 		if strings.HasPrefix(arg, proto) {
@@ -147,7 +148,7 @@ func isTCPNetworkAddress(arg string) bool {
 
 	parts := strings.Split(arg, ":")
 	if len(parts) == 2 || len(parts) == 3 {
-		if strings.HasPrefix(arg, "https://") {
+		if _, ok := protomap[parts[0]]; ok {
 			return true
 		}
 

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func loadFromArgs(args []string, serverName string, insecure bool) cert.Certific
 			go func() {
 				defer wg.Done()
 				if isTCPNetworkAddress(arg) {
+					arg = stdUrl(arg)
 					out <- cert.LoadCertificatesFromNetwork(arg, serverName, insecure)
 					return
 				}
@@ -112,19 +113,47 @@ func loadFromArgs(args []string, serverName string, insecure bool) cert.Certific
 	// sort certificates by input arguments
 	var certsSortedByArgs cert.CertificateLocations
 	for _, arg := range args {
+		arg = stdUrl(arg)
 		certsSortedByArgs = append(certsSortedByArgs, certsByArgs[arg])
 	}
 	return certsSortedByArgs
 }
 
+func stdUrl(arg string) string {
+
+	if !isTCPNetworkAddress(arg) {
+		return arg
+	}
+
+	protomap := map[string]string{
+		"https": "443",
+		"http":  "80",
+		"ssh":   "22",
+	}
+
+	for proto, port := range protomap {
+		proto = proto + "://"
+		if strings.HasPrefix(arg, proto) {
+			arg = strings.Replace(arg, proto, "", 1)
+			if !strings.Contains(arg, ":") {
+				arg += ":" + port
+			}
+		}
+	}
+	return arg
+}
+
 func isTCPNetworkAddress(arg string) bool {
 
 	parts := strings.Split(arg, ":")
-	if len(parts) != 2 {
-		return false
-	}
-	if _, err := strconv.Atoi(parts[1]); err != nil {
-		return false
+	if len(parts) == 2 || len(parts) == 3 {
+		if strings.HasPrefix(arg, "https://") {
+			return true
+		}
+
+		if _, err := strconv.Atoi(parts[len(parts)-1]); err != nil {
+			return false
+		}
 	}
 	return true
 }


### PR DESCRIPTION
The network connection should be specified as
`hostname:port`, but I wanted `https://hostname` as well. So I have added support for (examples)

- `https://www.google.com`
- `https://www.google.com:443`